### PR TITLE
feat(dev-env): add initial dev container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,38 @@
+# Use the modern Ubuntu LTS image from Microsoft as a stable base.
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Set non-interactive frontend to prevent installers from prompting for user input during build.
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install core dependencies and TFLint for code quality analysis.
+# The architecture is detected dynamically to ensure portability between arm64 (Mac M1/M2) and amd64 (Intel/Windows).
+RUN apt-get update && apt-get -y install --no-install-recommends curl ca-certificates gnupg software-properties-common wget unzip \
+    && ARCH=$(dpkg --print-architecture) \
+    && curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest \
+    | grep "browser_download_url.*_linux_${ARCH}.zip" \
+    | cut -d : -f 2,3 \
+    | tr -d \" \
+    | wget -qi - \
+    && unzip "tflint_linux_${ARCH}.zip" \
+    && rm "tflint_linux_${ARCH}.zip" \
+    && mv tflint /usr/local/bin/
+
+# Install Terraform using the official HashiCorp APT repository and the modern GPG key method.
+# This approach is multi-architecture by default.
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list \
+    && apt-get update \
+    && apt-get install -y terraform
+
+# Install the Google Cloud CLI.
+RUN curl -fsS https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && apt-get update && apt-get install -y google-cloud-cli
+
+# Install the GitHub CLI for repository and PR management from the terminal.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh
+
+# Clean up apt cache to reduce final image size.
+RUN apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Use the modern Ubuntu LTS image from Microsoft as a stable base.
-FROM mcr.microsoft.com/devcontainers/base:ubuntu
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
 
 # Set non-interactive frontend to prevent installers from prompting for user input during build.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  // Human-friendly name for the Dev Container, visible in the IDE.
+  "name": "Death Star - Infrastructure (Terraform & GCP)",
+  // Instructs Dev Containers to build a custom image using our Dockerfile.
+  // This approach provides maximum control and reliability.
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  // VS Code / Cursor specific customizations.
+  "customizations": {
+    "vscode": {
+      // Editor settings applied automatically inside the container for consistency.
+      "settings": {
+        "editor.formatOnSave": true,
+        "files.trimTrailingWhitespace": true
+      },
+      // Extensions to install inside the container to provide a rich development experience.
+      "extensions": [
+        "hashicorp.terraform", // Core Terraform language support.
+        "googlecloudtools.cloudcode", // GCP integration, secret management, etc.
+        "ms-vscode.azure-account", // Often used for unified cloud identity management.
+        "GitHub.vscode-pull-request-github" // Manage GitHub PRs directly in the IDE.
+      ]
+    }
+  },
+  // Specifies the default user to run as inside the container. 'vscode' is a standard non-root user.
+  "remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
-# death-star-infrastructure
-Terraform scripts for all GCP infrastructure.
+# Death Star Infrastructure
+
+![GitHub last commit](https://img.shields.io/github/last-commit/simaopgt/death-star-infrastructure?style=for-the-badge)
+![Repo size](https://img.shields.io/github/repo-size/simaopgt/death-star-infrastructure?style=for-the-badge)
+![License](https://img.shields.io/github/license/simaopgt/death-star-infrastructure?style=for-the-badge)
+
+This repository contains the standardized development environment (Dev Container) and all Infrastructure as Code (IaC) for the "Death Star" project. The infrastructure is managed using Terraform and provisions resources on the Google Cloud Platform (GCP).
+
+## 🚀 Overview
+
+The primary goal of this component is to define and manage the entire cloud infrastructure required to run the Death Star application stack. It also provides a fully configured, portable, and reproducible development environment to ensure consistency for all developers across any operating system.
+
+The environment comes pre-installed with all necessary tooling, including:
+* Terraform
+* Google Cloud CLI (`gcloud`)
+* GitHub CLI (`gh`)
+* TFLint for code quality
+
+## 📋 Prerequisites
+
+Before you begin, ensure you have the following installed on your local machine:
+
+1.  **Docker Desktop:** The engine used to run the Dev Container.
+2.  **Cursor (or VS Code):** An IDE that supports Dev Containers.
+3.  **Dev Containers Extension:** The official Microsoft extension (`ms-vscode-remote.remote-containers`) must be installed in your IDE.
+
+## 🛠️ How to Use
+
+### 1. Launching the Environment
+
+To get the development environment up and running, follow these steps:
+
+1.  **Clone the Repository:**
+    ```bash
+    git clone [https://github.com/simaopgt/death-star-infrastructure.git](https://github.com/simaopgt/death-star-infrastructure.git)
+    cd death-star-infrastructure
+    ```
+2.  **Open in IDE:** Open the `death-star-infrastructure` folder in Cursor or VS Code.
+3.  **Launch the Dev Container:** Open the Command Palette (`Cmd + Shift + P` or `Ctrl + Shift + P`) and run `Dev Containers: Rebuild and Reopen in Container`.
+
+The IDE will build the Docker image and launch the environment. Once complete, your terminal will be connected to the container.
+
+### 2. Basic Terraform Workflow
+
+Once inside the Dev Container, you can manage the infrastructure with standard Terraform commands:
+
+* **Initialize Terraform:** (Run this first)
+    ```bash
+    terraform init
+    ```
+* **Check for changes:**
+    ```bash
+    terraform plan
+    ```
+* **Apply changes:**
+    ```bash
+    terraform apply
+    ```
+
+## 🗺️ Roadmap
+
+The high-level roadmap for the infrastructure is tracked through the project's milestones in GitHub Projects.
+* [X] **M0: Foundation & Setup** (Current)
+* [ ] **M1-M5:** Provisioning of core application services (Cloud Run, Cloud SQL, etc.).
+
+See the [GitHub Project board](<https://github.com/users/simaopgt/projects/3>) for more details.
+
+## 🏛️ Architectural Decisions
+
+* **Custom Dockerfile over "Features"**: We use a custom `Dockerfile` to define the environment's tooling. This approach was chosen over the standard "Features" system to ensure maximum build reliability and portability.
+* **Infrastructure as Code (IaC)**: All infrastructure is managed declaratively using Terraform to ensure it is versioned, repeatable, and automated.
+* **Code Quality**: TFLint is included in the environment to enforce Terraform best practices and catch potential errors before deployment.
+
+##🤝 Contributing
+
+As this is a solo portfolio project, direct contributions are not expected. However, suggestions and issue reports are welcome. Please feel free to open an issue for any bugs or ideas.
+
+## 📄 License
+
+This project is distributed under the MIT License. See `LICENSE` for more information.


### PR DESCRIPTION
This commit introduces the initial development environment using Dev Containers.

It includes a custom Dockerfile to build a portable environment with Terraform, GCP CLI, GitHub CLI, and TFLint. This setup resolves build issues on M1 Macs and ensures a consistent developer experience across different operating systems.

Closes #1 